### PR TITLE
feat(store): worktree_root per sessie (schema v3) — ccf #120 Fase 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Format gebaseerd op [Keep a Changelog](https://keepachangelog.com/nl/1.1.0/).
 ## [Unreleased]
 
 ### Toegevoegd
+- **`worktree_root`-veld op sessies** (schema v3): `create_session()` + `manage.py create-session` accepteren `--worktree-root` (absolute git work-tree root, `rev-parse --show-toplevel`) en persisteren die per sessie. Maakt robuuste gedeelde-checkout-detectie in `/sessie-start` mogelijk (exacte work-tree i.p.v. mapnaam-heuristiek) — ccf #120 Fase 2. Veld is peer van `git_branch`: meegedragen bij `resume_session` + geëxposeerd in de overview-API. Back-compat via `_migrate_session_data` (v2→v3, default `None`) + `.get()`-deserialisatie. +2 tests (v2→v3-migratie, resume-preservatie) + `worktree_root`-asserts in de store/CLI create-session-tests.
 - `redact_username()` in `lib/jsonl_reader.py`: redacteert `/Users/<naam>` én de dash-encoded `-Users-<naam>` projectdir-vorm (+ `/home`-varianten) → `[USER]`, geïntegreerd in de export-redactieloop (`manage.py`, naast secrets/PII). Port van `aibuild-lab/agent-conversations-cairn` (claude-code-framework PLAN-2026-031 item E1); alleen delimiter-verankerde patronen overgenomen — de boundary-vorm gaf false-positives op proza. +4 tests.
 - System-reminder-strip uit user-turns in de JSONL-reader: `<system-reminder>…</system-reminder>`-blokken worden uit user-content verwijderd (harness-ruis), echte prompt blijft behouden. +1 test.
 

--- a/lib/models.py
+++ b/lib/models.py
@@ -48,6 +48,7 @@ class Session:
     awaiting_action: str | None = None  # Reason user action is needed
     events: list[dict] = field(default_factory=list)
     git_branch: str = "main"
+    worktree_root: str | None = None  # Absolute git work-tree root (rev-parse --show-toplevel)
     files_changed: list[str] = field(default_factory=list)
     commits: list[dict] = field(default_factory=list)
     decisions: list[str] = field(default_factory=list)

--- a/lib/store.py
+++ b/lib/store.py
@@ -40,6 +40,7 @@ from .validation import (
     MAX_REASON,
     MAX_ROADMAP_REF,
     MAX_TASK_SUBJECT,
+    MAX_WORKTREE_ROOT,
     validate_commits_json,
     validate_git_branch,
     validate_optional_string,
@@ -219,12 +220,14 @@ def create_session(
     intent: str,
     roadmap_ref: str | None = None,
     git_branch: str = "main",
+    worktree_root: str | None = None,
 ) -> Session:
     """Create a new active session."""
     validate_project_slug(project_slug)
     intent = validate_string_length(intent, "intent", MAX_INTENT)
     roadmap_ref = validate_optional_string(roadmap_ref, "roadmap_ref", MAX_ROADMAP_REF)
     git_branch = validate_git_branch(git_branch)
+    worktree_root = validate_optional_string(worktree_root, "worktree_root", MAX_WORKTREE_ROOT)
     session = Session(
         session_id=generate_session_id(),
         project_slug=project_slug,
@@ -234,6 +237,7 @@ def create_session(
         started_at=_now_iso(),
         last_heartbeat=_now_iso(),
         git_branch=git_branch,
+        worktree_root=worktree_root,
     )
     _save_session(session)
     _refresh_project_state(project_slug)
@@ -271,6 +275,7 @@ def _session_from_dict(data: dict) -> Session:
         awaiting_action=data.get("awaiting_action"),
         events=data.get("events", []),
         git_branch=data.get("git_branch", "main"),
+        worktree_root=data.get("worktree_root"),
         files_changed=data.get("files_changed", []),
         commits=data.get("commits", []),
         decisions=data.get("decisions", []),
@@ -280,15 +285,19 @@ def _session_from_dict(data: dict) -> Session:
     )
 
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 
 def _migrate_session_data(data: dict) -> dict:
     """Migrate session data from older schema versions to current."""
     version = data.get("schema_version", 1)
     if version < 2:
-        # v1 → v2: add schema_version and tasks field
+        # v1 → v2: add tasks field
         data.setdefault("tasks", [])
+    if version < 3:
+        # v2 → v3: add worktree_root field
+        data.setdefault("worktree_root", None)
+    if version < SCHEMA_VERSION:
         data["schema_version"] = SCHEMA_VERSION
     return data
 
@@ -677,6 +686,7 @@ def resume_session(session_id: str, new_intent: str | None = None) -> Session:
         project_slug = old.project_slug
         roadmap_ref = old.roadmap_ref
         git_branch = old.git_branch
+        worktree_root = old.worktree_root
         open_questions = old.open_questions
 
         # Mark old session as completed (resumed into new)
@@ -695,6 +705,7 @@ def resume_session(session_id: str, new_intent: str | None = None) -> Session:
         started_at=_now_iso(),
         last_heartbeat=_now_iso(),
         git_branch=git_branch,
+        worktree_root=worktree_root,
         open_questions=open_questions,
     )
     _save_session(new_session)
@@ -1142,6 +1153,7 @@ def _session_to_overview_dict(session: Session, **extra) -> dict:
         "roadmap_ref": session.roadmap_ref,
         "events": session.events[-5:],
         "git_branch": session.git_branch,
+        "worktree_root": session.worktree_root,
         "files_changed": session.files_changed,
         "decisions": session.decisions,
         "open_questions": session.open_questions,

--- a/lib/validation.py
+++ b/lib/validation.py
@@ -22,6 +22,7 @@ MAX_ACTIVITY = 300
 MAX_ROADMAP_REF = 100
 MAX_PROJECT_NAME = 100
 MAX_GIT_BRANCH = 200
+MAX_WORKTREE_ROOT = 4096
 
 # ---------------------------------------------------------------------------
 # Regex patterns

--- a/manage.py
+++ b/manage.py
@@ -41,6 +41,11 @@ def main() -> None:
     p.add_argument("--intent", required=True, help="What this session will do")
     p.add_argument("--roadmap-ref", help="Roadmap reference (e.g. 'FASE D.3')")
     p.add_argument("--git-branch", default="main")
+    p.add_argument(
+        "--worktree-root",
+        default=None,
+        help="Absolute git work-tree root (rev-parse --show-toplevel) for shared-checkout detection",
+    )
 
     p = sub.add_parser("get-session", help="Get session details")
     p.add_argument("session_id")
@@ -233,6 +238,7 @@ def _dispatch(args: argparse.Namespace) -> dict | list:
             intent=args.intent,
             roadmap_ref=args.roadmap_ref,
             git_branch=args.git_branch,
+            worktree_root=args.worktree_root,
         )
         return asdict(session)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,10 +83,12 @@ class TestSessionCommands:
             intent="Build feature",
             roadmap_ref="A1",
             git_branch="main",
+            worktree_root="/Users/dev/wt",
         ))
         assert "session_id" in result
         assert result["intent"] == "Build feature"
         assert result["status"] == "active"
+        assert result["worktree_root"] == "/Users/dev/wt"
 
     def test_get_session(self, session_id):
         result = _dispatch(ns(command="get-session", session_id=session_id))

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -123,6 +123,27 @@ class TestSchemaVersioning:
         loaded = store.get_session(s.session_id)
         assert loaded.intent == "Modern"
 
+    def test_v2_session_migrated_to_v3(self):
+        """A v2 session (no worktree_root) gains the field as None on read."""
+        sid = "sess_20260101T0000_beef"
+        path = store.SESSIONS_DIR / f"{sid}.json"
+        v2_data = {
+            "session_id": sid,
+            "project_slug": "proj",
+            "status": "active",
+            "intent": "v2 session",
+            "started_at": "2026-01-01T00:00:00+00:00",
+            "last_heartbeat": "2026-01-01T00:00:00+00:00",
+            "tasks": [],
+            "schema_version": 2,
+        }
+        with open(path, "w") as f:
+            json.dump(v2_data, f)
+
+        s = store.get_session(sid)
+        assert s is not None
+        assert s.worktree_root is None
+
 
 # ---------------------------------------------------------------------------
 # Session CRUD
@@ -136,13 +157,17 @@ class TestSessionCRUD:
             intent="Build feature",
             roadmap_ref="A1",
             git_branch="feature/x",
+            worktree_root="/Users/dev/repo-wt",
         )
         assert s.session_id.startswith("sess_")
         assert s.status == SessionStatus.ACTIVE
         assert s.intent == "Build feature"
         assert s.roadmap_ref == "A1"
         assert s.git_branch == "feature/x"
+        assert s.worktree_root == "/Users/dev/repo-wt"
         assert s.started_at != ""
+        # round-trip through disk preserves worktree_root
+        assert store.get_session(s.session_id).worktree_root == "/Users/dev/repo-wt"
 
     def test_get_session(self, session_id):
         s = store.get_session(session_id)
@@ -209,6 +234,17 @@ class TestSessionCRUD:
         old = store.get_session(session_id)
         assert old.status == SessionStatus.COMPLETED
         assert "Resumed as" in old.outcome
+
+    def test_resume_preserves_worktree_root(self):
+        """Resuming carries the work-tree root over, like git_branch."""
+        original = store.create_session(
+            project_slug="proj",
+            intent="Work",
+            worktree_root="/Users/dev/repo-wt",
+        )
+        store.park_session(original.session_id, reason="Break")
+        resumed = store.resume_session(original.session_id)
+        assert resumed.worktree_root == "/Users/dev/repo-wt"
 
     def test_resume_session_not_found(self):
         with pytest.raises(ValueError, match="not found"):


### PR DESCRIPTION
## Wat

Voegt een `worktree_root`-veld toe aan sessies (schema **v2→v3**):
- `create_session()` + `manage.py create-session` nemen `--worktree-root` (absolute git work-tree root, `git rev-parse --show-toplevel`).
- Veld is peer van `git_branch`: meegedragen bij `resume_session` en geëxposeerd in `_session_to_overview_dict`.
- Back-compat: `_migrate_session_data` v2→v3 (default `None`) + `.get()`-deserialisatie — bestaande session-JSONs blijven werken.

## Waarom

Maakt robuuste gedeelde-checkout-detectie in `/sessie-start` mogelijk: sleutelen op de exacte git-work-tree i.p.v. de mapnaam-heuristiek (sluit de "twee repos, zelfde mapnaam"-vals-positief).

## Tests

168 passed op de geraakte files (`test_store`, `test_cli`, `test_models`); +2 tests (v2→v3-migratie, resume-preservatie) + `worktree_root`-asserts in de create-session-tests. De 6 `test_search`-failures zijn pre-existing (#3, search-ranking — niet door deze PR geraakt).

## ⚠ Merge-volgorde

**Deze PR moet vóór de ccf-PR mergen.** De live `manage.py` is een symlink naar deze repo's `main`; de ccf-skill gaat `--worktree-root` meegeven aan `create-session` — zonder deze wijziging op `main` faalt dat op een onbekende arg.

Refs: RobinEste/claude-code-framework#120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
