### PR TITLE
feat(store): register-launch + worktree-padnormalisatie (PLAN-2026-032 keystone)

### DIFF
--- a/lib/models.py
+++ b/lib/models.py
@@ -49,6 +49,7 @@ class Session:
     events: list[dict] = field(default_factory=list)
     git_branch: str = "main"
     worktree_root: str | None = None  # Absolute git work-tree root (rev-parse --show-toplevel)
+    claude_session_id: str | None = None  # CLAUDE_CODE_SESSION_ID (launch-registratie-sleutel)
     files_changed: list[str] = field(default_factory=list)
     commits: list[dict] = field(default_factory=list)
     decisions: list[str] = field(default_factory=list)

--- a/lib/store.py
+++ b/lib/store.py
@@ -221,6 +221,7 @@ def create_session(
     roadmap_ref: str | None = None,
     git_branch: str = "main",
     worktree_root: str | None = None,
+    claude_session_id: str | None = None,
 ) -> Session:
     """Create a new active session."""
     validate_project_slug(project_slug)
@@ -228,6 +229,7 @@ def create_session(
     roadmap_ref = validate_optional_string(roadmap_ref, "roadmap_ref", MAX_ROADMAP_REF)
     git_branch = validate_git_branch(git_branch)
     worktree_root = validate_optional_string(worktree_root, "worktree_root", MAX_WORKTREE_ROOT)
+    claude_session_id = validate_optional_string(claude_session_id, "claude_session_id", 128)
     session = Session(
         session_id=generate_session_id(),
         project_slug=project_slug,
@@ -238,6 +240,7 @@ def create_session(
         last_heartbeat=_now_iso(),
         git_branch=git_branch,
         worktree_root=worktree_root,
+        claude_session_id=claude_session_id,
     )
     _save_session(session)
     _refresh_project_state(project_slug)
@@ -276,6 +279,7 @@ def _session_from_dict(data: dict) -> Session:
         events=data.get("events", []),
         git_branch=data.get("git_branch", "main"),
         worktree_root=data.get("worktree_root"),
+        claude_session_id=data.get("claude_session_id"),
         files_changed=data.get("files_changed", []),
         commits=data.get("commits", []),
         decisions=data.get("decisions", []),
@@ -285,7 +289,7 @@ def _session_from_dict(data: dict) -> Session:
     )
 
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 
 def _migrate_session_data(data: dict) -> dict:
@@ -297,6 +301,9 @@ def _migrate_session_data(data: dict) -> dict:
     if version < 3:
         # v2 → v3: add worktree_root field
         data.setdefault("worktree_root", None)
+    if version < 4:
+        # v3 → v4: add claude_session_id field
+        data.setdefault("claude_session_id", None)
     if version < SCHEMA_VERSION:
         data["schema_version"] = SCHEMA_VERSION
     return data
@@ -822,6 +829,50 @@ def get_stale_sessions(threshold_hours: int | None = None) -> list[Session]:
     return stale
 
 
+def _worktree_key(path: str | None) -> str:
+    """Comparison key for a worktree root: realpath + casefold.
+
+    The same checkout can be reached via a symlink (e.g. ~/Projects/X) or with
+    different casing (macOS is case-insensitive: /Users/robin/Odin vs /ODIN).
+    Resolving the real path and case-folding makes those routes compare equal,
+    so two sessions on one physical checkout detect each other.
+    """
+    if not path:
+        return ""
+    try:
+        return os.path.realpath(path).casefold()
+    except OSError:
+        return path.casefold()
+
+
+def register_launch(
+    claude_session_id: str,
+    project_slug: str,
+    worktree_root: str | None = None,
+    intent: str = "(launch — sessie-start volgt)",
+) -> Session:
+    """Idempotent launch registration keyed on the harness session id.
+
+    Called by the SessionStart hook on every launch (independent of /sessie-start),
+    so the dashboard has ground-truth about every live session — including
+    daily-first/IDE launches that never run /sessie-start. If an active session
+    with this claude_session_id already exists, heartbeat it and return it;
+    otherwise create a fresh one.
+    """
+    if not claude_session_id:
+        raise ValueError("claude_session_id is required")
+    for session in get_active_sessions():
+        if session.claude_session_id == claude_session_id:
+            return heartbeat(session.session_id) or session
+    real_root = os.path.realpath(worktree_root) if worktree_root else None
+    return create_session(
+        project_slug=project_slug,
+        intent=intent,
+        worktree_root=real_root,
+        claude_session_id=claude_session_id,
+    )
+
+
 def get_fresh_sessions_for_worktree(
     worktree_root: str, threshold_hours: int | None = None
 ) -> list[Session]:
@@ -839,8 +890,9 @@ def get_fresh_sessions_for_worktree(
 
     now = datetime.now(UTC)
     fresh = []
+    target_key = _worktree_key(worktree_root)
     for session in get_active_sessions():
-        if session.worktree_root != worktree_root:
+        if _worktree_key(session.worktree_root) != target_key:
             continue
         reference = session.last_heartbeat or session.started_at
         if not reference:

--- a/manage.py
+++ b/manage.py
@@ -47,6 +47,18 @@ def main() -> None:
         help="Absolute git work-tree root (rev-parse --show-toplevel) for shared-checkout detection",
     )
 
+    p = sub.add_parser(
+        "register-launch",
+        help="Idempotent launch registration keyed on the harness session id "
+             "(SessionStart hook): create or heartbeat; prints the dashboard session_id",
+    )
+    p.add_argument("--claude-session-id", required=True, help="CLAUDE_CODE_SESSION_ID")
+    p.add_argument("--project", required=True, help="Project slug")
+    p.add_argument("--worktree-root", default=None, help="Absolute git work-tree root")
+    p.add_argument(
+        "--intent", default="(launch — sessie-start volgt)", help="Placeholder intent"
+    )
+
     p = sub.add_parser("get-session", help="Get session details")
     p.add_argument("session_id")
 
@@ -251,6 +263,15 @@ def _dispatch(args: argparse.Namespace) -> dict | list:
             worktree_root=args.worktree_root,
         )
         return asdict(session)
+
+    if cmd == "register-launch":
+        session = store.register_launch(
+            claude_session_id=args.claude_session_id,
+            project_slug=args.project,
+            worktree_root=args.worktree_root,
+            intent=args.intent,
+        )
+        return session.session_id
 
     if cmd == "get-session":
         try:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1000,3 +1000,64 @@ class TestSessionIndex:
         assert s1.session_id in ids
         assert s3.session_id in ids
         assert s2.session_id not in ids
+
+
+class TestRegisterLaunch:
+    """Launch-onafhankelijke, idempotente registratie (PLAN-2026-032 keystone)."""
+
+    def test_creates_new_session_with_claude_id(self):
+        s = store.register_launch(
+            claude_session_id="claude-abc-123",
+            project_slug="test-project",
+            worktree_root="/tmp/wt-a",
+        )
+        assert s.claude_session_id == "claude-abc-123"
+        assert s.status == SessionStatus.ACTIVE
+
+    def test_idempotent_same_claude_id_reuses_one_record(self):
+        s1 = store.register_launch(
+            claude_session_id="claude-same", project_slug="test-project"
+        )
+        s2 = store.register_launch(
+            claude_session_id="claude-same", project_slug="test-project"
+        )
+        assert s1.session_id == s2.session_id
+        active = [
+            x
+            for x in store.get_active_sessions()
+            if x.claude_session_id == "claude-same"
+        ]
+        assert len(active) == 1
+
+    def test_distinct_claude_ids_create_distinct_sessions(self):
+        a = store.register_launch(claude_session_id="claude-A", project_slug="test-project")
+        b = store.register_launch(claude_session_id="claude-B", project_slug="test-project")
+        assert a.session_id != b.session_id
+
+    def test_claude_session_id_survives_roundtrip(self):
+        s = store.register_launch(
+            claude_session_id="claude-rt", project_slug="test-project"
+        )
+        reloaded = store.get_session(s.session_id)
+        assert reloaded is not None
+        assert reloaded.claude_session_id == "claude-rt"
+
+
+class TestWorktreeKey:
+    """Padnormalisatie zodat symlink/casing-routes naar één checkout matchen."""
+
+    def test_casefold_unifies_casing(self):
+        # /ODIN vs /Odin = zelfde map op case-insensitive FS
+        assert store._worktree_key("/Users/x/ODIN/ccf") == store._worktree_key(
+            "/Users/x/Odin/ccf"
+        )
+
+    def test_symlink_resolves_to_same_key(self, tmp_path):
+        real = tmp_path / "real_repo"
+        real.mkdir()
+        link = tmp_path / "link_repo"
+        link.symlink_to(real)
+        assert store._worktree_key(str(link)) == store._worktree_key(str(real))
+
+    def test_none_is_empty_key(self):
+        assert store._worktree_key(None) == ""


### PR DESCRIPTION
## Wat

Keystone (Fase 1) voor ccf **PLAN-2026-032** — launch-onafhankelijke sessie-isolatie (ccf issue #183). Geeft het dashboard ground-truth over élke live sessie, ook daily-first/IDE-launches die nooit `/sessie-start` draaien.

- **`Session.claude_session_id`** (schema v3→v4 + migratie) — stabiele sleutel = `CLAUDE_CODE_SESSION_ID`.
- **`store.register_launch(claude_session_id, project, worktree_root, intent)`** — idempotent: heartbeat een bestaande actieve sessie met die sleutel, anders aanmaken. Door de (nog te bouwen) SessionStart-hook aanroepbaar bij elke launch.
- **`store._worktree_key`** (realpath + casefold) — symlink/casing-routes naar één checkout matchen (`~/Projects` → `…/Odin` vs de canonieke `…/ODIN`); `get_fresh_sessions_for_worktree` vergelijkt nu genormaliseerd → twee sessies op één fysieke checkout detecteren elkaar.
- **CLI `register-launch`** — print het dashboard `session_id` (voor de hook).

## Test
7 nieuwe tests (idempotentie, roundtrip, normalisatie); **180 passed**, ruff clean (de 2 resterende `manage.py`-E501's zijn pre-existing op main).

## Vervolg (ccf-zijde)
SessionStart-hook-script + `settings.json`-matchers + `/sessie-start`-integratie (hergebruik de hook-sessie i.p.v. blind `create-session`). Backstop (pre-commit occupancy-guard, ccf-first) volgt.

Refs: RobinEste/claude-code-framework#183, PLAN-2026-032.

🤖 Generated with [Claude Code](https://claude.com/claude-code)