### PR TITLE
refactor(store): register-launch cleanup na /simplify

### DIFF
--- a/lib/store.py
+++ b/lib/store.py
@@ -849,7 +849,7 @@ def register_launch(
     claude_session_id: str,
     project_slug: str,
     worktree_root: str | None = None,
-    intent: str = "(launch — sessie-start volgt)",
+    intent: str | None = None,
 ) -> Session:
     """Idempotent launch registration keyed on the harness session id.
 
@@ -861,14 +861,18 @@ def register_launch(
     """
     if not claude_session_id:
         raise ValueError("claude_session_id is required")
+    # Slugify zoals register_project, zodat een rauwe repo-basename met hoofdletters/
+    # underscores (bv. AI-Readiness-Audit) niet stil door validate_project_slug valt.
+    project_slug = _slugify(project_slug)
     for session in get_active_sessions():
         if session.claude_session_id == claude_session_id:
             return heartbeat(session.session_id) or session
-    real_root = os.path.realpath(worktree_root) if worktree_root else None
+    # Geen store-tijd realpath: _worktree_key normaliseert (realpath + casefold) bij de
+    # vergelijking — dat is de enige normalisatie-laag (robuust tegen latere symlinks).
     return create_session(
         project_slug=project_slug,
-        intent=intent,
-        worktree_root=real_root,
+        intent=intent or "(launch — sessie-start volgt)",
+        worktree_root=worktree_root,
         claude_session_id=claude_session_id,
     )
 

--- a/manage.py
+++ b/manage.py
@@ -56,7 +56,7 @@ def main() -> None:
     p.add_argument("--project", required=True, help="Project slug")
     p.add_argument("--worktree-root", default=None, help="Absolute git work-tree root")
     p.add_argument(
-        "--intent", default="(launch — sessie-start volgt)", help="Placeholder intent"
+        "--intent", default=None, help="Placeholder intent (default: register_launch-default)"
     )
 
     p = sub.add_parser("get-session", help="Get session details")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1034,6 +1034,14 @@ class TestRegisterLaunch:
         b = store.register_launch(claude_session_id="claude-B", project_slug="test-project")
         assert a.session_id != b.session_id
 
+    def test_slugifies_raw_repo_basename(self):
+        # Een rauwe repo-basename (hoofdletters/underscores, bv. AI-Readiness-Audit)
+        # moet genormaliseerd worden i.p.v. stil door validate_project_slug te vallen.
+        s = store.register_launch(
+            claude_session_id="claude-slug", project_slug="AI_Readiness Audit"
+        )
+        assert s.project_slug == "ai-readiness-audit"
+
     def test_claude_session_id_survives_roundtrip(self):
         s = store.register_launch(
             claude_session_id="claude-rt", project_slug="test-project"


### PR DESCRIPTION
Cleanup-pass (/simplify) op de register-launch keystone (PR #7). Refs RobinEste/claude-code-framework#183, PLAN-2026-032.

- **Slug-normalisatie (functionele gap):** `register_launch` slugificeert nu `project_slug` (zoals `register_project`/`_slugify`). Zonder dit valt een rauwe repo-basename met hoofdletters/underscores (bv. `AI-Readiness-Audit`, `BeeHaive`) stil door `validate_project_slug` → de SessionStart-hook (die de basename rauw doorgeeft) zou voor die projecten **niets registreren**.
- **Eén normalisatie-laag:** store-tijd `os.path.realpath` weg uit `register_launch`; `_worktree_key` (realpath + casefold) normaliseert al op compare-tijd — robuuster tegen latere symlink-wijzigingen, en geen filesystem-stat op het launch-pad.
- **Single-source intent-default:** literal alleen nog in de `register_launch`-signatuur; argparse-default = `None`.
- +1 test (slugify); **110 passed**, ruff clean (2 resterende `manage.py`-E501's pre-existing op main).