### PR TITLE
feat(cli): fresh-sessions — verse checkout-bezetters als JSON (Fase 2)

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -158,6 +158,16 @@ def main() -> None:
         help="Git work-tree root being entered (git rev-parse --show-toplevel)",
     )
 
+    p = sub.add_parser(
+        "fresh-sessions",
+        help="List fresh active sessions occupying a work-tree (JSON) — used by the "
+             "pre-commit occupancy-guard to detect a contested checkout",
+    )
+    p.add_argument(
+        "--path", required=True,
+        help="Git work-tree root (git rev-parse --show-toplevel)",
+    )
+
     p = sub.add_parser("archive", help="Archive old completed sessions")
     p.add_argument("--days", type=int, help="Archive sessions older than N days (default: config)")
     p.add_argument(
@@ -386,6 +396,17 @@ def _dispatch(args: argparse.Namespace) -> dict | list:
     if cmd == "launch-plan":
         occupied = store.get_fresh_sessions_for_worktree(args.path)
         return "WORKTREE" if occupied else "MAIN"
+
+    if cmd == "fresh-sessions":
+        sessions = store.get_fresh_sessions_for_worktree(args.path)
+        return [
+            {
+                "session_id": s.session_id,
+                "claude_session_id": s.claude_session_id,
+                "started_at": s.started_at,
+            }
+            for s in sessions
+        ]
 
     if cmd == "cleanup-stale":
         cleaned = store.cleanup_stale_sessions()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -287,6 +287,22 @@ class TestQueryCommands:
         result = _dispatch(ns(command="launch-plan", path="/Users/dev/repo"))
         assert result == "MAIN"
 
+    def test_fresh_sessions_lists_occupants(self, project_slug):
+        # fresh-sessions geeft de verse bezetters van een checkout als JSON-lijst,
+        # met de velden die de pre-commit occupancy-guard nodig heeft.
+        store.register_launch(
+            claude_session_id="claude-1", project_slug=project_slug,
+            worktree_root="/Users/dev/repo",
+        )
+        store.register_launch(
+            claude_session_id="claude-2", project_slug=project_slug,
+            worktree_root="/Users/dev/repo",
+        )
+        result = _dispatch(ns(command="fresh-sessions", path="/Users/dev/repo"))
+        assert isinstance(result, list)
+        assert {r["claude_session_id"] for r in result} == {"claude-1", "claude-2"}
+        assert all("session_id" in r and "started_at" in r for r in result)
+
     def test_launch_plan_ignores_stale_session(self, project_slug):
         # A crashed session stays ACTIVE but goes stale; it must not be counted
         # as occupying the checkout (threshold_hours=0 ages out even a fresh one).


### PR DESCRIPTION
Ondersteunt de pre-commit occupancy-guard van PLAN-2026-032 Fase 2 (ccf #183).

`fresh-sessions --path <toplevel>` → JSON-lijst van verse actieve sessies op die checkout (`session_id`, `claude_session_id`, `started_at`), door `get_fresh_sessions_for_worktree` te hergebruiken. `launch-plan` geeft alleen MAIN/WORKTREE; de guard heeft de lijst nodig voor contested-detectie (≥2) + primair-bewust blokkeren (oudste = primair). +1 CLI-test; 160 passed.